### PR TITLE
Rails and JSON gem security updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # using ruby 1.8.6, rubygems 1.8.10 and bundler 1.0.22
 source 'http://rubygems.org'
 
-gem 'rails', '=2.3.15'
+gem 'rails', '=2.3.17'
 gem 'builder', '=2.1.2'
 gem 'exception_notification', '=2.3.3.0'
 gem 'will_paginate', '=2.3.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    actionmailer (2.3.15)
-      actionpack (= 2.3.15)
-    actionpack (2.3.15)
-      activesupport (= 2.3.15)
-      rack (~> 1.1.3)
-    activerecord (2.3.15)
-      activesupport (= 2.3.15)
-    activeresource (2.3.15)
-      activesupport (= 2.3.15)
-    activesupport (2.3.15)
+    actionmailer (2.3.17)
+      actionpack (= 2.3.17)
+    actionpack (2.3.17)
+      activesupport (= 2.3.17)
+      rack (~> 1.1.0)
+    activerecord (2.3.17)
+      activesupport (= 2.3.17)
+    activeresource (2.3.17)
+      activesupport (= 2.3.17)
+    activesupport (2.3.17)
     blankslate (3.1.2)
     builder (2.1.2)
     cucumber (1.2.1)
@@ -37,7 +37,7 @@ GEM
       rake (>= 0.8.1)
       rubyforge (>= 0.4.4)
     i18n (0.6.1)
-    json (1.7.6)
+    json (1.7.7)
     json_pure (1.7.6)
     just_giving (0.3.0)
       faraday
@@ -52,15 +52,15 @@ GEM
     multipart-post (1.1.5)
     newrelic_rpm (3.5.5.38)
     nokogiri (1.5.6)
-    rack (1.1.4)
+    rack (1.1.6)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rails (2.3.15)
-      actionmailer (= 2.3.15)
-      actionpack (= 2.3.15)
-      activerecord (= 2.3.15)
-      activeresource (= 2.3.15)
-      activesupport (= 2.3.15)
+    rails (2.3.17)
+      actionmailer (= 2.3.17)
+      actionpack (= 2.3.17)
+      activerecord (= 2.3.17)
+      activeresource (= 2.3.17)
+      activesupport (= 2.3.17)
       rake (>= 0.8.3)
     rake (10.0.3)
     rspec (1.3.1)
@@ -104,7 +104,7 @@ DEPENDENCIES
   mocha
   newrelic_rpm
   nokogiri
-  rails (= 2.3.15)
+  rails (= 2.3.17)
   rake
   rspec-rails (= 1.3.3)
   sqlite3


### PR DESCRIPTION
Bumped Rails version to 2.3.17 and JSON to 1.7.7

Rails release post: http://weblog.rubyonrails.org/2013/2/11/SEC-ANN-Rails-3-2-12-3-1-11-and-2-3-17-have-been-released/
